### PR TITLE
Move certificates to secret and rollback parameter name changes

### DIFF
--- a/cft_sidecar.yaml
+++ b/cft_sidecar.yaml
@@ -1080,9 +1080,9 @@ Resources:
                 LOG_GROUP_NAME=${log_group}
                 LOCATION_BASED_POLICY_EVAL=${EnableLocationBasedPolicyEval}
                 SSO_LOGIN_URL=${IdPSSOLoginURL}
-                IDP_CERTIFICATE=${IdPCertificate}
-                SIDECAR_IDP_PUBLIC_CERT=${!SIDECAR_IDP_PUBLIC_CERT}
-                SIDECAR_IDP_PRIVATE_KEY=${!SIDECAR_IDP_PRIVATE_KEY}
+                IDP_CERTIFICATE="${IdPCertificate}"
+                SIDECAR_IDP_PUBLIC_CERT="${!SIDECAR_IDP_PUBLIC_CERT}"
+                SIDECAR_IDP_PRIVATE_KEY="${!SIDECAR_IDP_PRIVATE_KEY}"
                 NGINX_RESOLVER=$NGINX_RESOLVER
                 SECRETS_LOCATION=${secrets_location}
                 TLS_SKIP_VERIFY=${tls_skip_verify}
@@ -1110,7 +1110,7 @@ Resources:
                 $env_var
                 $proxy_env
                 EOF
-              - sidecar_endpoint: !If [sidecarDNSNameNotEmpty, !Ref SidecarDNSName, !GetAtt ECSNLB.DNSName]
+              - sidecar_endpoint: !If [sidecarDNSNameNotEmpty, !Ref SidecarDNSName, !GetAtt LoadBalancer.DNSName]
                 log_group: !Ref CloudwatchLogGroup
                 tls_skip_verify:
                   Fn::If:
@@ -1255,7 +1255,7 @@ Resources:
                 !Sub 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:*',
               ]
 
-  ECSNLB:
+  LoadBalancer:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
     Properties:
       Name: !GetAtt GetNamePrefixCustomResource.NamePrefix
@@ -1278,7 +1278,7 @@ Resources:
     Type: AWS::CloudFormation::CustomResource
     Properties:
       ServiceToken:               !GetAtt CreateCyralMacrosLambda.Arn
-      LoadBalancerArn:            !Ref ECSNLB
+      LoadBalancerArn:            !Ref LoadBalancer
       LoadBalancerCertificateArn: !Ref LoadBalancerCertificateArn
       NamePrefix:                 !GetAtt GetNamePrefixCustomResource.NamePrefix
       SidecarPorts:               !Ref SidecarPorts
@@ -1464,7 +1464,7 @@ Resources:
           - https://cyral-public-assets-us-east-1.s3.amazonaws.com/cloudformation/sidecar_resources/${resources_template_version}/cft_sidecar_resources.yaml
           - resources_template_version: !FindInMap [Constants, ResourcesTemplate, Version]
       Parameters:
-        LoadBalancerArn:            !Ref ECSNLB
+        LoadBalancerArn:            !Ref LoadBalancer
         LoadBalancerCertificateArn: !Ref LoadBalancerCertificateArn
         NamePrefix:                 !GetAtt GetNamePrefixCustomResource.NamePrefix
         SidecarPorts:               !Ref SidecarPorts
@@ -1503,7 +1503,7 @@ Resources:
       Name: !Ref SidecarDNSName
       Comment: DNS for Cyral Sidecar
       ResourceRecords:
-      - !GetAtt ECSNLB.DNSName
+      - !GetAtt LoadBalancer.DNSName
       TTL: 300
       Type: 'CNAME'
 
@@ -1738,24 +1738,24 @@ Resources:
     Properties:
       ServiceToken: !GetAtt SelfSignedCertificateLambda.Arn
       SecretId: !Ref SidecarCreatedCertificateSecret
-      Hostname: !If [sidecarDNSNameNotEmpty, !Ref SidecarDNSName, !GetAtt ECSNLB.DNSName]
+      Hostname: !If [sidecarDNSNameNotEmpty, !Ref SidecarDNSName, !GetAtt LoadBalancer.DNSName]
 
   SidecarCACertificate:
     Type: AWS::CloudFormation::CustomResource
     Properties:
       ServiceToken: !GetAtt SelfSignedCertificateLambda.Arn
       SecretId: !Ref SidecarCACertificateSecret
-      Hostname: !If [sidecarDNSNameNotEmpty, !Ref SidecarDNSName, !GetAtt ECSNLB.DNSName]
+      Hostname: !If [sidecarDNSNameNotEmpty, !Ref SidecarDNSName, !GetAtt LoadBalancer.DNSName]
       IsCACertificate: true
 
 Outputs:
   SidecarDNS:
     Description: Sidecar DNS name
-    Value: !If [mustCreateDNSRecordSet, !Ref SidecarDNSName, !GetAtt ECSNLB.DNSName]
+    Value: !If [mustCreateDNSRecordSet, !Ref SidecarDNSName, !GetAtt LoadBalancer.DNSName]
 
   SidecarLoadBalancerDNS:
     Description: Sidecar load balancer DNS name
-    Value: !GetAtt ECSNLB.DNSName
+    Value: !GetAtt LoadBalancer.DNSName
   
   SidecarSecurityGroupID:
     Description: Sidecar security group id

--- a/cft_sidecar.yaml
+++ b/cft_sidecar.yaml
@@ -14,7 +14,7 @@ Metadata:
     - Label:
         default: 'Networking and Security Configuration'
       Parameters:
-      - VpcId
+      - VPC
       - Subnets
       - SidecarPorts
       - AssociatePublicIpAddress
@@ -105,7 +105,7 @@ Parameters:
     Default: ""
     AllowedPattern: ^((\d+\,)*(\d+))*$
 
-  VpcId:
+  VPC:
     Description: "AWS VPC ID to deploy sidecar to"
     Type: AWS::EC2::VPC::Id
     AllowedPattern: ".+"
@@ -1130,7 +1130,7 @@ Resources:
     Type: "AWS::EC2::SecurityGroup"
     Properties:
       GroupDescription: Enables SSH Access to Sidecar Hosts
-      VpcId: !Ref VpcId
+      VpcId: !Ref VPC
       Tags:
         - Key: "Name"
           Value: !Join ["-", [!GetAtt GetNamePrefixCustomResource.NamePrefix, "sidecar"]]
@@ -1284,7 +1284,7 @@ Resources:
       SidecarPorts:               !Ref SidecarPorts
       LoadBalancerTLSPorts:       !Ref LoadBalancerTLSPorts
       LoadBalancerStickyPorts:    !Ref LoadBalancerStickyPorts
-      VPC:                        !Ref VpcId
+      VPC:                        !Ref VPC
       Retries:                    0
       PermissionsBoundary:        !Ref PermissionsBoundary
       MacrosTemplateVersion:      !FindInMap [Constants, MacrosTemplate, Version]
@@ -1470,7 +1470,7 @@ Resources:
         SidecarPorts:               !Ref SidecarPorts
         LoadBalancerTLSPorts:       !Ref LoadBalancerTLSPorts
         LoadBalancerStickyPorts:    !Ref LoadBalancerStickyPorts
-        VPC:                        !Ref VpcId
+        VPC:                        !Ref VPC
         # This is here to make sure that the Cyral Macros stack is created
         # before this resource.
         CreateMacrosIsDone:         !Ref CreateCyralMacrosCustomResource

--- a/cft_sidecar.yaml
+++ b/cft_sidecar.yaml
@@ -1081,8 +1081,8 @@ Resources:
                 LOCATION_BASED_POLICY_EVAL=${EnableLocationBasedPolicyEval}
                 SSO_LOGIN_URL=${IdPSSOLoginURL}
                 IDP_CERTIFICATE=${IdPCertificate}
-                SIDECAR_IDP_PUBLIC_CERT=${SidecarPublicIdPCertificate}
-                SIDECAR_IDP_PRIVATE_KEY=${SidecarPrivateIdPKey}
+                SIDECAR_IDP_PUBLIC_CERT=${!SIDECAR_IDP_PUBLIC_CERT}
+                SIDECAR_IDP_PRIVATE_KEY=${!SIDECAR_IDP_PRIVATE_KEY}
                 NGINX_RESOLVER=$NGINX_RESOLVER
                 SECRETS_LOCATION=${secrets_location}
                 TLS_SKIP_VERIFY=${tls_skip_verify}
@@ -1110,7 +1110,7 @@ Resources:
                 $env_var
                 $proxy_env
                 EOF
-              - sidecar_endpoint: !If [sidecarDNSNameNotEmpty, !Ref SidecarDNSName, !GetAtt LoadBalancer.DNSName]
+              - sidecar_endpoint: !If [sidecarDNSNameNotEmpty, !Ref SidecarDNSName, !GetAtt ECSNLB.DNSName]
                 log_group: !Ref CloudwatchLogGroup
                 tls_skip_verify:
                   Fn::If:
@@ -1255,7 +1255,7 @@ Resources:
                 !Sub 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:*',
               ]
 
-  LoadBalancer:
+  ECSNLB:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
     Properties:
       Name: !GetAtt GetNamePrefixCustomResource.NamePrefix
@@ -1278,7 +1278,7 @@ Resources:
     Type: AWS::CloudFormation::CustomResource
     Properties:
       ServiceToken:               !GetAtt CreateCyralMacrosLambda.Arn
-      LoadBalancerArn:            !Ref LoadBalancer
+      LoadBalancerArn:            !Ref ECSNLB
       LoadBalancerCertificateArn: !Ref LoadBalancerCertificateArn
       NamePrefix:                 !GetAtt GetNamePrefixCustomResource.NamePrefix
       SidecarPorts:               !Ref SidecarPorts
@@ -1464,7 +1464,7 @@ Resources:
           - https://cyral-public-assets-us-east-1.s3.amazonaws.com/cloudformation/sidecar_resources/${resources_template_version}/cft_sidecar_resources.yaml
           - resources_template_version: !FindInMap [Constants, ResourcesTemplate, Version]
       Parameters:
-        LoadBalancerArn:            !Ref LoadBalancer
+        LoadBalancerArn:            !Ref ECSNLB
         LoadBalancerCertificateArn: !Ref LoadBalancerCertificateArn
         NamePrefix:                 !GetAtt GetNamePrefixCustomResource.NamePrefix
         SidecarPorts:               !Ref SidecarPorts
@@ -1483,7 +1483,8 @@ Resources:
     Properties:
       Description: Cyral Sidecar secret with client id, secret and container registry key.
       Name: !If [hasSecretsLocation, !Ref SecretsLocation, !Sub '/cyral/sidecars/${SidecarId}/secrets']
-      SecretString: !Sub '{"clientId":"${ClientId}", "clientSecret": "${ClientSecret}", "containerRegistryKey": "${ContainerRegistryKey}"}'
+
+      SecretString: !Sub '{"clientId":"${ClientId}", "clientSecret": "${ClientSecret}", "containerRegistryKey": "${ContainerRegistryKey}", "sidecarPublicIdpCertificate": "${SidecarPublicIdPCertificate}", "sidecarPrivateIdpKey": "${SidecarPrivateIdPKey}"}'
       KmsKeyId: !If [useKMSSecrets, !Ref SecretsKMSArn, !Ref AWS::NoValue]
       Tags:
         - Key: "Stack"
@@ -1502,7 +1503,7 @@ Resources:
       Name: !Ref SidecarDNSName
       Comment: DNS for Cyral Sidecar
       ResourceRecords:
-      - !GetAtt LoadBalancer.DNSName
+      - !GetAtt ECSNLB.DNSName
       TTL: 300
       Type: 'CNAME'
 
@@ -1737,24 +1738,24 @@ Resources:
     Properties:
       ServiceToken: !GetAtt SelfSignedCertificateLambda.Arn
       SecretId: !Ref SidecarCreatedCertificateSecret
-      Hostname: !If [sidecarDNSNameNotEmpty, !Ref SidecarDNSName, !GetAtt LoadBalancer.DNSName]
+      Hostname: !If [sidecarDNSNameNotEmpty, !Ref SidecarDNSName, !GetAtt ECSNLB.DNSName]
 
   SidecarCACertificate:
     Type: AWS::CloudFormation::CustomResource
     Properties:
       ServiceToken: !GetAtt SelfSignedCertificateLambda.Arn
       SecretId: !Ref SidecarCACertificateSecret
-      Hostname: !If [sidecarDNSNameNotEmpty, !Ref SidecarDNSName, !GetAtt LoadBalancer.DNSName]
+      Hostname: !If [sidecarDNSNameNotEmpty, !Ref SidecarDNSName, !GetAtt ECSNLB.DNSName]
       IsCACertificate: true
 
 Outputs:
   SidecarDNS:
     Description: Sidecar DNS name
-    Value: !If [mustCreateDNSRecordSet, !Ref SidecarDNSName, !GetAtt LoadBalancer.DNSName]
+    Value: !If [mustCreateDNSRecordSet, !Ref SidecarDNSName, !GetAtt ECSNLB.DNSName]
 
   SidecarLoadBalancerDNS:
     Description: Sidecar load balancer DNS name
-    Value: !GetAtt LoadBalancer.DNSName
+    Value: !GetAtt ECSNLB.DNSName
   
   SidecarSecurityGroupID:
     Description: Sidecar security group id

--- a/cft_sidecar.yaml
+++ b/cft_sidecar.yaml
@@ -9,8 +9,8 @@ Metadata:
       Parameters:
       - SidecarId
       - ControlPlane
-      - ClientId
-      - ClientSecret
+      - SidecarClientID
+      - SidecarClientSecret
     - Label:
         default: 'Networking and Security Configuration'
       Parameters:
@@ -39,7 +39,7 @@ Metadata:
       - SidecarCACertificateSecretArn
       - SidecarCACertificateRoleArn
       - SidecarCustomHostRole
-      - IAMPolicies
+      - UserPolicies
       - PermissionsBoundary
     - Label:
         default: 'SIEM Configuration'
@@ -135,14 +135,14 @@ Parameters:
     Default: ""
 
   DeploySecrets:
-    Description: "Create the AWS Secrets Manager resource at `SecretsLocation` storing `ClientId`, `ClientSecret` and `ContainerRegistryKey`"
+    Description: "Create the AWS Secrets Manager resource at `SecretsLocation` storing `SidecarClientID`, `SidecarClientSecret` and `ContainerRegistryKey`"
     Type: String
     AllowedValues: [true, false]
     Default: true
     ConstraintDescription: must specify 'true' or 'false'.
 
   SecretsLocation:
-    Description: "(Optional) Location in AWS Secrets Manager to store `ClientId`, `ClientSecret` and `ContainerRegistryKey`. If unset, will assume `/cyral/sidecars/<SIDECAR_ID>/secrets`."
+    Description: "(Optional) Location in AWS Secrets Manager to store `SidecarClientID`, `SidecarClientSecret` and `ContainerRegistryKey`. If unset, will assume `/cyral/sidecars/<SIDECAR_ID>/secrets`."
     Type: String
     Default: ""
 
@@ -156,13 +156,13 @@ Parameters:
     Type: String
     Default: ""
 
-  ClientId:
+  SidecarClientID:
     NoEcho: true
     Description: "Sidecar client ID"
     Type: String
     AllowedPattern: ".+"
 
-  ClientSecret:
+  SidecarClientSecret:
     NoEcho: true
     Description: "Sidecar client secret"
     Type: String
@@ -310,7 +310,7 @@ Parameters:
     Description: Cloudwatch log group name. In order to use this log group, set the logging integration in the control plane.
     Default: ""
 
-  IAMPolicies:
+  UserPolicies:
     Type: CommaDelimitedList
     Description: (Optional) List of IAM policies ARNs that will be attached to the sidecar IAM role (Comma Delimited List)
     Default: ""
@@ -461,7 +461,7 @@ Conditions:
 
   sidecarCustomHostRoleEmpty: !Equals [!Ref SidecarCustomHostRole, '']
   loadBalancerSubnetsEmpty: !Equals [!Join [",", !Ref LoadBalancerSubnets] , '']
-  mustAttachIAMPolicies: !Not [!Equals [!Join ["", !Ref IAMPolicies], ""]]
+  mustAttachUserPolicies: !Not [!Equals [!Join ["", !Ref UserPolicies], ""]]
   useKMSSecrets: !Not [!Equals [!Ref SecretsKMSArn, '']]
   useKMSEBS: !Not [!Equals [!Ref EC2EBSKMSArn, '']]
   useKMSSecretsOrEBS: !Or [!Condition useKMSSecrets, !Condition useKMSEBS]
@@ -619,7 +619,7 @@ Resources:
                 - ec2.amazonaws.com
             Action:
               - "sts:AssumeRole"
-      ManagedPolicyArns: !If [mustAttachIAMPolicies, !Ref IAMPolicies, !Ref AWS::NoValue]
+      ManagedPolicyArns: !If [mustAttachUserPolicies, !Ref UserPolicies, !Ref AWS::NoValue]
 
   SidecarHostPolicy:
     Type: "AWS::IAM::Policy"
@@ -1484,7 +1484,7 @@ Resources:
       Description: Cyral Sidecar secret with client id, secret and container registry key.
       Name: !If [hasSecretsLocation, !Ref SecretsLocation, !Sub '/cyral/sidecars/${SidecarId}/secrets']
 
-      SecretString: !Sub '{"clientId":"${ClientId}", "clientSecret": "${ClientSecret}", "containerRegistryKey": "${ContainerRegistryKey}", "sidecarPublicIdpCertificate": "${SidecarPublicIdPCertificate}", "sidecarPrivateIdpKey": "${SidecarPrivateIdPKey}"}'
+      SecretString: !Sub '{"clientId":"${SidecarClientID}", "clientSecret": "${SidecarClientSecret}", "containerRegistryKey": "${ContainerRegistryKey}", "sidecarPublicIdpCertificate": "${SidecarPublicIdPCertificate}", "sidecarPrivateIdpKey": "${SidecarPrivateIdPKey}"}'
       KmsKeyId: !If [useKMSSecrets, !Ref SecretsKMSArn, !Ref AWS::NoValue]
       Tags:
         - Key: "Stack"


### PR DESCRIPTION
## Description of the change

Move certificates to the sidecar secret and rollback the LB name change to avoid its recreation.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Jira issue referenced in commit message and/or PR title

### Testing
Upgrade from `v4.9` sidecar with CP-downloaded CFT to this static template with a `v4.10` sidecar.
