### PR TITLE
ENG-13003: Changing env variable to be one line

### DIFF
--- a/cft_sidecar.yaml
+++ b/cft_sidecar.yaml
@@ -1094,10 +1094,7 @@ Resources:
                 CYRAL_SIDECAR_ENDPOINT=${sidecar_endpoint}
                 CYRAL_SIDECAR_VERSION=$SIDECAR_VERSION
 
-                CYRAL_DEPLOYMENT_PROPERTIES='{
-                  "account-id": "${AWS::AccountId}",
-                  "region": "${AWS::Region}"
-                }'
+                CYRAL_DEPLOYMENT_PROPERTIES='{ "account-id": "${AWS::AccountId}","region": "${AWS::Region}" }'
                 CYRAL_CERTIFICATE_MANAGER_TLS_KEY=${!SIDECAR_TLS_KEY}
                 CYRAL_CERTIFICATE_MANAGER_TLS_CERT=${!SIDECAR_TLS_CERT}
                 CYRAL_CERTIFICATE_MANAGER_CA_KEY=${!SIDECAR_CA_KEY}


### PR DESCRIPTION
## Description of the change

> The `CYRAL_DEPLOYMENT_PROPERTIES` was being created with a value spanning multiple lines when being written to the `.env` file. This makes it a single line.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Jira issue referenced in commit message and/or PR title

### Testing
> I deployed an upgrade to one of my sidecars and tested successfully
